### PR TITLE
Relax conflicts for SSSD to allow VLC installation.

### DIFF
--- a/fedora-minimal.spec
+++ b/fedora-minimal.spec
@@ -279,7 +279,6 @@ Conflicts:	sssd-ipa sssd-krb5 sssd-krb5-common sssd-ldap
 Conflicts:	adcli
 Conflicts:	cyrus-sasl-gssapi
 Conflicts:	lubipa_hbac
-Conflicts:	libsmbclient
 Conflicts:	python3-sssdconfig
 Conflicts:	sssd-client
 Conflicts:	sssd-common
@@ -293,10 +292,7 @@ Conflicts:	libsss_idmap
 Conflicts:	libsss_nss_idmap
 Conflicts:	libsss_sudo libsss_autofs
 Conflicts:	c-ares
-Conflicts:	libldb
 Conflicts:	libdhash
-Conflicts:	libtalloc
-Conflicts:	libtevent
 Conflicts:	http-parser
 %description	conflicts-sssd
 Conflicts with setroubleshoot packages.


### PR DESCRIPTION
Addressing
```
package vlc-core-1:3.0.9-21.fc31.x86_64 requires libsmbclient.so.0(SMBCLIENT_0.1.0)(64bit), but none of the providers can be installed
```

Removing the `lib*` conflicts shouldn't hurt as they can be easily purged with `dnf autoremove`.